### PR TITLE
Clean up the API

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,0 +1,159 @@
+package pbstream
+
+import (
+	"math"
+
+	"github.com/pkg/errors"
+)
+
+// Parse takes a message and begins the parsing....
+func Parse(bz []byte) *Field {
+	return &Field{
+		data: bz,
+	}
+}
+
+// Field is a set of bytes being parsed.
+// It can store and detect error
+type Field struct {
+	data  []byte
+	index int // current distance read, advances each call
+	err   *multierror
+	// TODO: bitmask of viewed/Repeated fields
+}
+
+func (f *Field) Bytes(i int) []byte {
+	if f == nil {
+		return nil
+	}
+	// TODO
+	return nil
+}
+
+func (f *Field) String(i int) string {
+	// TODO
+	return string(f.Bytes(i))
+}
+
+func (f *Field) Number(i int) Number {
+	if f == nil {
+		return Number(0)
+	}
+	// TODO
+	return Number(0)
+}
+
+func (f *Field) Field(i int) *Field {
+	if f == nil {
+		return nil
+	}
+	// TODO
+	return nil
+}
+
+func (f *Field) Error() error {
+	if f == nil {
+		// TODO: return error not found?????
+		return nil
+	}
+	return f.err.Resolve()
+}
+
+func (f *Field) Close() error {
+	// TODO: skip til end, look for dups
+	return f.Error()
+}
+
+/*
+RepeatedNumber gives us an iterator to see all the numbers
+at the field.
+
+  var sum int32
+  iter := f.RepeatedNumber(3)
+  for ; iter.Valid(); iter.Next() {
+    sum += iter.Value().Int32
+  }
+  if err := iter.Close(); err != nil {
+      return err
+  }
+*/
+func (f *Field) RepeatedNumber(i int) IterNum {
+	return nil
+}
+
+func (f *Field) RepeatedField(i int) IterField {
+	return nil
+}
+
+// IterNum allows iteration over a series of numbers...
+type IterNum interface {
+	Valid() bool
+	Next()
+	Value() Number
+	Close() error // (or stored in the parent field???)
+}
+
+// IterField allows iteration over a series of fields...
+type IterField interface {
+	Valid() bool
+	Next()
+	Value() *Field
+	Close() error // (or stored in the parent field???), needed????
+}
+
+// Number is the raw bytes parsed from a numeric field
+// Caller should interpret them as below
+type Number uint64
+
+func (n Number) Int64() int64 {
+	return int64(n)
+}
+
+func (n Number) Int32() int32 {
+	return int32(n)
+}
+
+func (n Number) Bool() bool {
+	return n != 0
+}
+
+func (n Number) Float64() float64 {
+	return math.Float64frombits(uint64(n))
+}
+
+func (n Number) Sint64() int64 {
+	return UnpackSint(uint64(n))
+}
+
+// multierror does nice handling to join errors
+type multierror []error
+
+// Add can concatonate, even for empty me
+func (me *multierror) Add(err error) *multierror {
+	err = errors.WithStack(err)
+	var base []error
+	if me != nil {
+		base = *me
+	}
+	*me = append(base, err)
+	return me
+}
+
+func (me *multierror) Resolve() error {
+	if me == nil || len(*me) == 0 {
+		return nil
+	}
+	if len(*me) == 1 {
+		return (*me)[0]
+	}
+	return me
+}
+
+func (me *multierror) Error() string {
+	return "TODO: combine all"
+}
+
+// Fmt should work like pkg.Errors, show all sub-errors, concatentated
+func (me *multierror) Fmt() string {
+	return "TODO: combine all"
+}

--- a/api.go
+++ b/api.go
@@ -26,8 +26,17 @@ func (s *Struct) Bytes(i int) []byte {
 	if s == nil {
 		return nil
 	}
-	// TODO
-	return nil
+	bz, _, err := ExtractField(s.data, int32(i))
+	if err != nil {
+		s.err.Add(err)
+		return nil
+	}
+	res, err := ParseBytesField(bz)
+	if err != nil {
+		s.err.Add(err)
+		return nil
+	}
+	return res
 }
 
 func (s *Struct) String(i int) string {
@@ -39,16 +48,25 @@ func (s *Struct) Number(i int) Number {
 	if s == nil {
 		return Number(0)
 	}
-	// TODO
-	return Number(0)
+	bz, wireType, err := ExtractField(s.data, int32(i))
+	if err != nil {
+		s.err.Add(err)
+		return Number(0)
+	}
+	val, _, err := ParseAnyInt(wireType, bz)
+	if err != nil {
+		s.err.Add(err)
+		return Number(0)
+	}
+	return Number(val)
 }
 
 func (s *Struct) Struct(i int) *Struct {
 	if s == nil {
 		return nil
 	}
-	// TODO
-	return nil
+	bz := s.Bytes(i)
+	return Parse(bz)
 }
 
 // OneOf will find the first field that matches any of those choices
@@ -117,6 +135,14 @@ func (n Number) Int64() int64 {
 
 func (n Number) Int32() int32 {
 	return int32(n)
+}
+
+func (n Number) Uint64() uint64 {
+	return uint64(n)
+}
+
+func (n Number) Uint32() uint32 {
+	return uint32(n)
 }
 
 func (n Number) Bool() bool {

--- a/api.go
+++ b/api.go
@@ -7,61 +7,67 @@ import (
 )
 
 // Parse takes a message and begins the parsing....
-func Parse(bz []byte) *Field {
-	return &Field{
+func Parse(bz []byte) *Struct {
+	return &Struct{
 		data: bz,
 	}
 }
 
-// Field is a set of bytes being parsed.
+// Struct is a set of bytes being parsed.
 // It can store and detect error
-type Field struct {
+type Struct struct {
 	data  []byte
 	index int // current distance read, advances each call
 	err   *multierror
 	// TODO: bitmask of viewed/Repeated fields
 }
 
-func (f *Field) Bytes(i int) []byte {
-	if f == nil {
+func (s *Struct) Bytes(i int) []byte {
+	if s == nil {
 		return nil
 	}
 	// TODO
 	return nil
 }
 
-func (f *Field) String(i int) string {
+func (s *Struct) String(i int) string {
 	// TODO
-	return string(f.Bytes(i))
+	return string(s.Bytes(i))
 }
 
-func (f *Field) Number(i int) Number {
-	if f == nil {
+func (s *Struct) Number(i int) Number {
+	if s == nil {
 		return Number(0)
 	}
 	// TODO
 	return Number(0)
 }
 
-func (f *Field) Field(i int) *Field {
-	if f == nil {
+func (s *Struct) Struct(i int) *Struct {
+	if s == nil {
 		return nil
 	}
 	// TODO
 	return nil
 }
 
-func (f *Field) Error() error {
-	if f == nil {
+// OneOf will find the first field that matches any of those choices
+func (s *Struct) OneOf(choices ...int) (*Struct, int) {
+	// TODO
+	return nil, 0
+}
+
+func (s *Struct) Error() error {
+	if s == nil {
 		// TODO: return error not found?????
 		return nil
 	}
-	return f.err.Resolve()
+	return s.err.Resolve()
 }
 
-func (f *Field) Close() error {
+func (s *Struct) Close() error {
 	// TODO: skip til end, look for dups
-	return f.Error()
+	return s.Error()
 }
 
 /*
@@ -77,11 +83,11 @@ at the field.
       return err
   }
 */
-func (f *Field) RepeatedNumber(i int) IterNum {
+func (s *Struct) RepeatedNumber(i int) IterNum {
 	return nil
 }
 
-func (f *Field) RepeatedField(i int) IterField {
+func (s *Struct) RepeatedStruct(i int) IterStruct {
 	return nil
 }
 
@@ -90,18 +96,18 @@ type IterNum interface {
 	Valid() bool
 	Next()
 	Value() Number
-	Close() error // (or stored in the parent field???)
+	Close() error // (or stored in the parent struct???)
 }
 
-// IterField allows iteration over a series of fields...
-type IterField interface {
+// IterStruct allows iteration over a series of structs...
+type IterStruct interface {
 	Valid() bool
 	Next()
-	Value() *Field
-	Close() error // (or stored in the parent field???), needed????
+	Value() *Struct
+	Close() error // (or stored in the parent struct???), needed????
 }
 
-// Number is the raw bytes parsed from a numeric field
+// Number is the raw bytes parsed from a numeric struct
 // Caller should interpret them as below
 type Number uint64
 
@@ -156,4 +162,35 @@ func (me *multierror) Error() string {
 // Fmt should work like pkg.Errors, show all sub-errors, concatentated
 func (me *multierror) Fmt() string {
 	return "TODO: combine all"
+}
+
+// Bitmask stores info for up to 32 fields,
+// Each one is represented by 2 bits:
+//
+//   * 0 - never seen, single field
+//   * 1 - already seen, error upon next seen
+//   * 2 - expect field multiple times
+//
+// Valid transitions are:
+//
+//   * 0 -> {Add, Close} -> 1
+//   * 0 -> {Repeat} -> 2
+//   * 2 -> {Add} -> 2
+//   * 2 -> {Close} -> 1
+//   * All others will return errors
+type Bitmask uint64
+
+func (b *Bitmask) Seen(i int) error {
+	// TODO
+	return nil
+}
+
+func (b *Bitmask) Close(i int) error {
+	// TODO
+	return nil
+}
+
+func (b *Bitmask) Repeat(i int) error {
+	// TODO
+	return nil
 }

--- a/api_test.go
+++ b/api_test.go
@@ -13,7 +13,7 @@ func ExampleField() {
 	}
 
 	str := Parse(bz)
-	fee := str.Field(1)
+	fee := str.Struct(1)
 	feeAmt := fee.Number(1).Int64()
 	feeDenom := fee.String(2)
 	if err := fee.Close(); err != nil {
@@ -21,23 +21,25 @@ func ExampleField() {
 	}
 	fmt.Printf("Fee: %d %s\n", feeAmt, feeDenom)
 
-	send := str.Field(2)
-	if send == nil {
-		fmt.Println("Not send msg")
-	} else {
-		rcpt := send.Bytes(2)
-		coin := send.Field(3)
+	msg, idx := str.OneOf(2, 3, 4)
+	switch idx {
+	case 2:
+		rcpt := msg.Bytes(2)
+		coin := msg.Struct(3)
 		sendAmt := coin.Number(1).Int64()
 		sendDenom := coin.String(2)
-		if err := send.Close(); err != nil {
+		if err := msg.Close(); err != nil {
 			fmt.Printf("Send parse error: %+v\n", err)
 		}
 		fmt.Printf("SendTx: %d %s to %X\n", sendAmt, sendDenom, rcpt)
+	case 3:
+		fmt.Println("Is issue msg")
+	case 4:
+		fmt.Println("Is other msg...")
+	default:
+		fmt.Printf("Unknown oneof %d\n", idx)
 	}
 
-	if str.Field(3) == nil {
-		fmt.Println("Not issue msg")
-	}
 	// this can check for duplicates, bad-fields
 	if err := str.Close(); err != nil {
 		fmt.Printf("Buffer parse error: %+v\n", err)
@@ -45,5 +47,4 @@ func ExampleField() {
 
 	// Output: Fee: 500 PHO
 	// SendTx: 18500 ATOM to 7423126382
-	// Not issue msg
 }

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,49 @@
+package pbstream
+
+import (
+	"fmt"
+	"io/ioutil"
+)
+
+func ExampleField() {
+	bz, err := ioutil.ReadFile("testdata/send_msg.bin")
+	if err != nil {
+		fmt.Println("Cannot read file")
+		return
+	}
+
+	str := Parse(bz)
+	fee := str.Field(1)
+	feeAmt := fee.Number(1).Int64()
+	feeDenom := fee.String(2)
+	if err := fee.Close(); err != nil {
+		fmt.Printf("Fee parse error: %+v\n", err)
+	}
+	fmt.Printf("Fee: %d %s\n", feeAmt, feeDenom)
+
+	send := str.Field(2)
+	if send == nil {
+		fmt.Println("Not send msg")
+	} else {
+		rcpt := send.Bytes(2)
+		coin := send.Field(3)
+		sendAmt := coin.Number(1).Int64()
+		sendDenom := coin.String(2)
+		if err := send.Close(); err != nil {
+			fmt.Printf("Send parse error: %+v\n", err)
+		}
+		fmt.Printf("SendTx: %d %s to %X\n", sendAmt, sendDenom, rcpt)
+	}
+
+	if str.Field(3) == nil {
+		fmt.Println("Not issue msg")
+	}
+	// this can check for duplicates, bad-fields
+	if err := str.Close(); err != nil {
+		fmt.Printf("Buffer parse error: %+v\n", err)
+	}
+
+	// Output: Fee: 500 PHO
+	// SendTx: 18500 ATOM to 7423126382
+	// Not issue msg
+}

--- a/api_test.go
+++ b/api_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 )
 
-func ExampleField() {
+func ExampleStruct() {
 	bz, err := ioutil.ReadFile("testdata/send_msg.bin")
 	if err != nil {
 		fmt.Println("Cannot read file")
@@ -38,6 +38,10 @@ func ExampleField() {
 		fmt.Println("Is other msg...")
 	default:
 		fmt.Printf("Unknown oneof %d\n", idx)
+	}
+	if err := msg.Close(); err != nil {
+		fmt.Printf("Msg error: %+v\n", err)
+		return
 	}
 
 	// this can check for duplicates, bad-fields


### PR DESCRIPTION
new file `api.go` that exposes an easy-to-use version of the interface, building on parser.go.

Compare the two examples and see if more to refine first:

Old way (with tons of unchecked errors):
https://github.com/confio/pbstream/blob/clean-api/parser_test.go#L177-L212

New proposal (that actually verifies if there are errors):
https://github.com/confio/pbstream/blob/clean-api/api_test.go#L8-L55

Similar amounts of code, question is which is nicer to use.